### PR TITLE
Improvement for website list

### DIFF
--- a/monitor2.json
+++ b/monitor2.json
@@ -16,7 +16,7 @@
         "tabReloadIntervalSeconds": 7200
       },
       {
-        "url": "https://dashboard.unity3d.com/gaming/organizations/18966623382592/projects/79ed4d15-e4f1-42b2-ae76-bc1a261a4625/cloud-diagnostics/crashes-exceptions?tag=%21%3DClosed",
+        "url": "https://media.tenor.com/images/037e90361340211bb57b794eaf061175/tenor.gif",
         "duration": 40,
         "tabReloadIntervalSeconds": 7200
       },


### PR DESCRIPTION
I suggest that we avoid displaying the outdated and obvious news about the MSP2 Nebula client crash, which occurs approximately 95% of the time due to our company's incompetency. Instead, it would be more beneficial to showcase a useful and entertaining GIF on our TV screen that adds value to our business. In recognition of our Head of Safety's diligent efforts, I recommend featuring a humorous GIF that would lighten the mood and provide a pleasant moment for the team. This would not only entertain our employees but also inspire them to appreciate and recognize their coworkers' hard work and accomplishments.